### PR TITLE
Feature/deploy and launch

### DIFF
--- a/factorio-deploy.py
+++ b/factorio-deploy.py
@@ -19,16 +19,17 @@ start_game = True
 ## Get information from filesystem
 user_dir = ""
 factorio_mod_dir = ""
-factorio_install_dir = ""
+steam_exe = ""
 
 user_dir = os.path.expanduser('~')
 if platform.system() == "Windows":
     factorio_mod_dir = os.path.join(user_dir, "AppData", "Roaming", "Factorio", "mods")
     import winreg
     key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Valve\\Steam")
-    factorio_install_dir = winreg.QueryValueEx(key, "SteamExe")[0]
+    steam_exe = winreg.QueryValueEx(key, "SteamExe")[0]
 else:
     factorio_mod_dir = os.path.join(user_dir, ".factorio", "mods")
+    steam_exe = "steam"
 
 if not os.path.exists(factorio_mod_dir):
     print ("No Factorio mod directory found. Aborting.")
@@ -104,7 +105,7 @@ if deploy_mod:
 
 if start_game:
     print("\nStarting Factorio Game")
-    game = factorio_install_dir + " steam://rungameid/427520"
+    game = steam_exe + " steam://rungameid/427520"
     print("run command:", game)
     subprocess.call(game)
 

--- a/factorio-deploy.py
+++ b/factorio-deploy.py
@@ -109,7 +109,6 @@ if deploy_mod:
 
 if start_game:
     print("\nStarting Factorio Game")
-    game = steam_exe + " steam://rungameid/427520"
-    print("run command:", game)
+    print("run command:", steam_exe, steam_game_id)
     subprocess.call([steam_exe, steam_game_id])
 

--- a/factorio-deploy.py
+++ b/factorio-deploy.py
@@ -20,6 +20,7 @@ start_game = True
 user_dir = ""
 factorio_mod_dir = ""
 steam_exe = ""
+steam_game_id = "steam://rungameid/427520"
 
 user_dir = os.path.expanduser('~')
 if platform.system() == "Windows":
@@ -107,5 +108,5 @@ if start_game:
     print("\nStarting Factorio Game")
     game = steam_exe + " steam://rungameid/427520"
     print("run command:", game)
-    subprocess.call(game)
+    subprocess.call([steam_exe, steam_game_id])
 

--- a/factorio-deploy.py
+++ b/factorio-deploy.py
@@ -10,17 +10,23 @@ import zipfile
 import json
 
 import platform
+import subprocess
 
 ## Configuration Section
 deploy_mod = True
+start_game = True
 
 ## Get information from filesystem
 user_dir = ""
 factorio_mod_dir = ""
+factorio_install_dir = ""
 
 user_dir = os.path.expanduser('~')
 if platform.system() == "Windows":
     factorio_mod_dir = os.path.join(user_dir, "AppData", "Roaming", "Factorio", "mods")
+    import winreg
+    key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Valve\\Steam")
+    factorio_install_dir = winreg.QueryValueEx(key, "SteamExe")[0]
 else:
     factorio_mod_dir = os.path.join(user_dir, ".factorio", "mods")
 
@@ -95,3 +101,10 @@ if deploy_mod:
     if os.path.exists(destination):
         os.remove(destination)
     shutil.move(zipname, destination)
+
+if start_game:
+    print("\nStarting Factorio Game")
+    game = factorio_install_dir + " steam://rungameid/427520"
+    print("run command:", game)
+    subprocess.call(game)
+

--- a/factorio-deploy.py
+++ b/factorio-deploy.py
@@ -12,6 +12,10 @@ import json
 import platform
 import subprocess
 
+# Load Windows RedEdit Lib
+if platform.system() == "Windows":
+    import winreg
+
 ## Configuration Section
 deploy_mod = True
 start_game = True
@@ -25,7 +29,6 @@ steam_game_id = "steam://rungameid/427520"
 user_dir = os.path.expanduser('~')
 if platform.system() == "Windows":
     factorio_mod_dir = os.path.join(user_dir, "AppData", "Roaming", "Factorio", "mods")
-    import winreg
     key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, "Software\\Valve\\Steam")
     steam_exe = winreg.QueryValueEx(key, "SteamExe")[0]
 else:


### PR DESCRIPTION
This should fixe #3 

There is a new configuration line, line 21:
`start_game = True`

Set this to False and the script won't launch the game after a deploy.